### PR TITLE
Force Git to treat all files as text, not binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.html text
+*.css text
+*.js text
+*.md text


### PR DESCRIPTION
🛠 What this PR does:
This PR resolves an issue where the project files (index.html, main.css, script.js, and README.md) were being incorrectly detected as binary by Git. As a result, GitHub was not showing the number of lines of code added or changed — which is important for SCM evaluation.

✅ Changes made:
Added a .gitattributes file to explicitly tell Git to treat .html, .css, .js, and .md files as text files.

Re-tracked the affected files using git rm --cached and re-added them to update Git’s file-type detection.

