### PR TITLE
Fixed BMI calculation formula for Imperial units by applying 703 multiplier

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,12 +238,7 @@
                     <h5>International System of Units (SI)</h5>
                     <p>BMI = weight (kg) ÷ (height (m))²</p>
                     <h5>Imperial System</h5>
-                    <!-- 🔴 Error 1: Wrong BMI formula used in Imperial system -->
-                    <!-- ❌ Fix: Multiply result by 703 in Imperial formula -->
-                    <!-- BMI = weight (lb) / (height (in)^2) ❌ Wrong -->
-                    <!-- BMI = weight (lb) / (height (in)^2) * 703 ✅ Correct -->
-
-                    <p>BMI = weight (lb) ÷ (height (inches))²</p>
+                    <p>BMI = weight (lb) ÷ (height (inches)²) * 703</p>
                 </div>
             </div>
 


### PR DESCRIPTION
#33 This PR fixes an error in the BMI calculation formula for the Imperial unit system. The original formula was missing the necessary multiplier of 703, which is required to correctly convert the calculation from metric to imperial units.