### PR TITLE
Bmi progress bar styling

### DIFF
--- a/main.css
+++ b/main.css
@@ -140,3 +140,11 @@ progress::-webkit-progress-value {
 .bmi-progress-normal {
     background-color: #66cc66;
 }
+
+.bmi-progress-overweight {
+    background-color: #ffcc00;
+}
+
+.bmi-progress-obese {
+    background-color: #ff3333;
+}

--- a/main.css
+++ b/main.css
@@ -132,3 +132,11 @@ progress::-webkit-progress-bar {
 progress::-webkit-progress-value {
     border-radius: 12px;
 }
+
+.bmi-progress-underweight {
+    background-color: #99ccff;
+}
+
+.bmi-progress-normal {
+    background-color: #66cc66;
+}

--- a/main.css
+++ b/main.css
@@ -124,3 +124,11 @@ progress {
     margin-top: 10px;
     background-color: #f0f0f0;
 }
+
+progress::-webkit-progress-bar {
+    border-radius: 12px;
+}
+
+progress::-webkit-progress-value {
+    border-radius: 12px;
+}


### PR DESCRIPTION
### Summary
Added custom styles for a BMI progress bar with rounded corners and color indicators for different BMI categories.

### Changes
- Rounded corners using `-webkit-progress-bar` and `-webkit-progress-value`
- Added background colors for:
  - Underweight (`#99ccff`)
  - Normal (`#66cc66`)
  - Overweight (`#ffcc00`)
  - Obese (`#ff3333`)
