### PR TITLE
Add BMI Quiz Logic for Category-Specific and General Questions

### DIFF
--- a/quiz.js
+++ b/quiz.js
@@ -85,5 +85,15 @@ document.addEventListener("DOMContentLoaded", () => {
 
 
 
+    function displayQuestion(index) {
+        const q = filteredQuestions[index];
+        const questionElement = document.getElementById("question");
+        const optionsElement = document.getElementById("options");
+        const nextBtn = document.getElementById("next-btn");
+    
+        questionElement.innerText = q.question;
+        optionsElement.innerHTML = "";
+        nextBtn.disabled = true;
+    }
     
 });

--- a/quiz.js
+++ b/quiz.js
@@ -63,6 +63,16 @@ document.addEventListener("DOMContentLoaded", () => {
     ];
 
 
+    // 🔀 Shuffle helper function
+    function shuffle(array) {
+        for (let i = array.length - 1; i > 0; i--) {
+            const j = Math.floor(Math.random() * (i + 1));
+            [array[i], array[j]] = [array[j], array[i]];
+        }
+    }
+
+    const categoryQuestions = questions.filter(q => q.bmiRange === bmiCategory);
+    const generalQuestions = questions.filter(q => q.bmiRange === "all").slice(0, 2);
 
 
 

--- a/quiz.js
+++ b/quiz.js
@@ -74,7 +74,14 @@ document.addEventListener("DOMContentLoaded", () => {
     const categoryQuestions = questions.filter(q => q.bmiRange === bmiCategory);
     const generalQuestions = questions.filter(q => q.bmiRange === "all").slice(0, 2);
 
+    shuffle(categoryQuestions);
+    shuffle(generalQuestions);
 
+    const filteredQuestions = [...categoryQuestions.slice(0, 5), ...generalQuestions];
+    shuffle(filteredQuestions);
+
+    let currentQuestionIndex = 0;
+    let score = 0;
 
 
 


### PR DESCRIPTION
This PR adds logic to:
- Filter questions based on BMI category and general pool
- Shuffle question order using Fisher-Yates
- Dynamically render quiz questions and options
- Track current index and score
#70 Major issue solved